### PR TITLE
Add the cookie banner for PostHog

### DIFF
--- a/components/cookies.tsx
+++ b/components/cookies.tsx
@@ -1,0 +1,84 @@
+"use client"
+import { CornerDownLeft } from "lucide-react"
+import { usePostHog } from "posthog-js/react"
+import { useEffect, useState } from "react"
+import { Button } from "./ui/button"
+
+type CookieConsent = "undecided" | "yes" | "no"
+
+export function cookieConsentGiven(): CookieConsent {
+    const consent = localStorage.getItem("cookie_consent")
+    return consent === "yes" || consent === "no" ? consent : "undecided"
+}
+
+export default function Cookies() {
+    const [consentGiven, setConsentGiven] = useState<CookieConsent | "">("")
+    const posthog = usePostHog()
+
+    useEffect(() => {
+        // We want this to only run once the client loads
+        // or else it causes a hydration error
+        setConsentGiven(cookieConsentGiven())
+
+        const handleKeyPress = (event: KeyboardEvent) => {
+            if (event.key === "Enter" && cookieConsentGiven() === "undecided") {
+                handleAcceptCookies()
+            }
+        }
+
+        window.addEventListener("keydown", handleKeyPress)
+        return () => window.removeEventListener("keydown", handleKeyPress)
+    }, [])
+
+    useEffect(() => {
+        if (consentGiven !== "undecided") {
+            posthog.set_config({
+                persistence:
+                    consentGiven === "yes" ? "localStorage+cookie" : "memory",
+            })
+            console.log(
+                "setting persistence",
+                consentGiven === "yes" ? "localStorage+cookie" : "memory",
+            )
+        }
+    }, [consentGiven])
+
+    const handleAcceptCookies = () => {
+        localStorage.setItem("cookie_consent", "yes")
+        setConsentGiven("yes")
+    }
+
+    const handleDeclineCookies = () => {
+        localStorage.setItem("cookie_consent", "no")
+        setConsentGiven("no")
+    }
+
+    return (
+        <>
+            {consentGiven === "undecided" && (
+                <div className="fixed bottom-0 right-0 z-50 w-full max-w-md p-6">
+                    <div className="rounded-lg border border-white/20 bg-black/50 p-3 shadow-md backdrop-blur-xl">
+                        <div className="flex flex-col gap-2">
+                            <p>
+                                We use a single first-party cookie for product
+                                analytics.
+                            </p>
+                            <div className="flex justify-end gap-2">
+                                <Button
+                                    variant="ghost"
+                                    onClick={handleDeclineCookies}
+                                >
+                                    I don't want a cookie
+                                </Button>
+                                <Button onClick={handleAcceptCookies}>
+                                    Accept
+                                    <CornerDownLeft />
+                                </Button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </>
+    )
+}

--- a/components/providers.tsx
+++ b/components/providers.tsx
@@ -6,17 +6,23 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import posthog from "posthog-js"
 import { PostHogProvider } from "posthog-js/react"
 import { useState } from "react"
+import { cookieConsentGiven } from "./cookies"
 
 function CSPostHogProvider({ children }: { children: React.ReactNode }) {
-    // disable posthog for now
-    return <>{children}</>
-
     if (typeof window !== "undefined") {
         posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
             api_host: "/ingest",
             ui_host: process.env.NEXT_PUBLIC_POSTHOG_UI_HOST,
-            person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well
+            person_profiles: "identified_only", // or 'always' to create profiles for anonymous users as well,
+            persistence:
+                cookieConsentGiven() === "yes"
+                    ? "localStorage+cookie"
+                    : "memory",
         })
+        console.log(
+            "setting persistence on init",
+            cookieConsentGiven() === "yes" ? "localStorage+cookie" : "memory",
+        )
     }
     return <PostHogProvider client={posthog}>{children}</PostHogProvider>
 }


### PR DESCRIPTION
This PR adds a cookie banner and enables PostHog in SongUp.

Currently, PostHog only supports page memory and cookie-based tracking.

This means that the "cookieless" variant is much less accurate due to the nature of page memory - being cleared on refresh.
PostHog currently has plans to introduce better cookieless tracking based on server hashes https://github.com/PostHog/posthog/issues/25117 - which is the way Vercel Analytics, Umami, Fathom and Plausible do it. This way of doing cookieless tracking is much better in terms of accuracy, and we will implement it as soon as a beta is ready.

