### PR TITLE
Host settings flow on room creation

### DIFF
--- a/app/host/actions.ts
+++ b/app/host/actions.ts
@@ -1,36 +1,53 @@
 "use server"
 
+import { roomSettingsSchema } from "@/lib/schema/room-settings"
 import { getSession } from "@/lib/session"
 import { createAdminClient } from "@/lib/supabase/admin"
-import { getErrorRedirect, getStatusRedirect } from "@/lib/utils"
+import { getStatusRedirect } from "@/lib/utils"
+import { ActionState } from "@/types/action-state"
 import { redirect } from "next/navigation"
 
-export async function createRoom() {
+export async function createRoom(
+    _prevState: ActionState,
+    formData: FormData,
+): Promise<ActionState> {
+    // parse the form data
+    const validatedFields = roomSettingsSchema.safeParse({
+        max_songs_per_user: Number(formData.get("max_songs_per_user")),
+    })
+
+    if (!validatedFields.success) {
+        console.log(validatedFields.error.flatten().fieldErrors)
+        return {
+            ok: false,
+            error: "The form data is invalid",
+        }
+    }
+
     const session = await getSession()
     session.isLoggedIn = true
 
     const supabase = createAdminClient()
 
     // Create a new room in the database
-    const { data, error } = await supabase
+    const { data: room, error } = await supabase
         .from("rooms")
         .insert({
             host: session.uuid,
+            max_songs_per_user: validatedFields.data.max_songs_per_user,
         })
         .select()
         .single()
 
-    if (error || !data) {
-        redirect(
-            getErrorRedirect(
-                "/host",
-                "Room creation failed",
-                error?.message ?? "An unknown error occurred",
-            ),
-        )
+    if (error || !room) {
+        console.error(error)
+        return {
+            ok: false,
+            error: "Room creation failed",
+        }
     }
 
     await session.save()
 
-    redirect(getStatusRedirect(`/host/${data.code}`, "Room created"))
+    redirect(getStatusRedirect(`/host/${room.code}`, "Room created"))
 }

--- a/app/host/create-dialog.tsx
+++ b/app/host/create-dialog.tsx
@@ -1,0 +1,28 @@
+import { RoomSettingsForm } from "@/components/host/room-settings"
+import { Button } from "@/components/ui/button"
+import {
+    DialogContent,
+    DialogTitle,
+    DialogTrigger,
+} from "@/components/ui/dialog"
+
+import { Dialog } from "@/components/ui/dialog"
+import { Plus } from "lucide-react"
+import { createRoom } from "./actions"
+
+export function CreateRoomDialog() {
+    return (
+        <Dialog>
+            <DialogTrigger asChild>
+                <Button>
+                    <Plus />
+                    Create Room
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogTitle>Create Room</DialogTitle>
+                <RoomSettingsForm action={createRoom} />
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/app/host/page.tsx
+++ b/app/host/page.tsx
@@ -1,13 +1,11 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
-import { SubmitButton } from "@/components/ui/submit-button"
 import { getSession } from "@/lib/session"
 import { createAdminClient } from "@/lib/supabase/admin"
 import { Room } from "@/types/global"
 import { formatDistance } from "date-fns"
-import { Plus } from "lucide-react"
 import { Metadata } from "next"
 import Link from "next/link"
-import { createRoom } from "./actions"
+import { CreateRoomDialog } from "./create-dialog"
 
 export const metadata: Metadata = {
     title: "Host",
@@ -91,16 +89,11 @@ export default async function HostHubPage() {
             <Card className="flex flex-col items-center justify-center">
                 <CardHeader>
                     <CardTitle className="text-purple-600">
-                        Create a Room
+                        Host a new room
                     </CardTitle>
                 </CardHeader>
                 <CardContent>
-                    <form action={createRoom}>
-                        <SubmitButton>
-                            <Plus />
-                            Create Room
-                        </SubmitButton>
-                    </form>
+                    <CreateRoomDialog />
                 </CardContent>
             </Card>
         </div>

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
       "name": "knowtheweb",
       "dependencies": {
         "@formkit/auto-animate": "^0.8.2",
+        "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-label": "^2.1.2",
         "@radix-ui/react-progress": "^1.1.2",
         "@radix-ui/react-scroll-area": "^1.2.3",
         "@radix-ui/react-slot": "^1.1.2",
@@ -28,11 +30,13 @@
         "qrcode.react": "^4.2.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-hook-form": "^7.54.2",
         "react-icons": "^5.4.0",
         "react-youtube": "^10.1.0",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "ytmusic-api": "^5.3.0",
+        "zod": "^3.24.1",
       },
       "devDependencies": {
         "@types/node": "^20.17.17",
@@ -90,6 +94,8 @@
     "@eslint/js": ["@eslint/js@8.57.1", "", {}, "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q=="],
 
     "@formkit/auto-animate": ["@formkit/auto-animate@0.8.2", "", {}, "sha512-SwPWfeRa5veb1hOIBMdzI+73te5puUBHmqqaF1Bu7FjvxlYSz/kJcZKSa9Cg60zL0uRNeJL2SbRxV6Jp6Q1nFQ=="],
+
+    "@hookform/resolvers": ["@hookform/resolvers@3.10.0", "", { "peerDependencies": { "react-hook-form": "^7.0.0" } }, "sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag=="],
 
     "@humanwhocodes/config-array": ["@humanwhocodes/config-array@0.13.0", "", { "dependencies": { "@humanwhocodes/object-schema": "^2.0.3", "debug": "^4.3.1", "minimatch": "^3.0.5" } }, "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw=="],
 
@@ -198,6 +204,8 @@
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.2", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.1", "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-callback-ref": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zxwE80FCU7lcXUGWkdt6XpTTCKPitG1XKOwViTxHVKIJhZl9MvIl2dVHeZENCWD9+EdWv05wlaEkRXUykU27RA=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.0", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-EJUrI8yYh7WOjNOqpoJaf1jlFIH2LvtgAl+YcFqNCa+4hj64ZXmPkAKOFs/ukjz3byN6bdb/AVUqHkI8/uWWMA=="],
+
+    "@radix-ui/react-label": ["@radix-ui/react-label@2.1.2", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-zo1uGMTaNlHehDyFQcDZXRJhUPDuukcnHz0/jnrup0JA6qL+AFpAnty+7VKa9esuU5xTblAZzTGYJKSKaBxBhw=="],
 
     "@radix-ui/react-portal": ["@radix-ui/react-portal@1.1.4", "", { "dependencies": { "@radix-ui/react-primitive": "2.0.2", "@radix-ui/react-use-layout-effect": "1.1.0" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA=="],
 
@@ -854,6 +862,8 @@
     "react": ["react@19.0.0", "", {}, "sha512-V8AVnmPIICiWpGfm6GLzCR/W5FXLchHop40W4nXBmdlEceh16rCN8O8LNWm5bh5XUX91fh7KpA+W0TgMKmgTpQ=="],
 
     "react-dom": ["react-dom@19.0.0", "", { "dependencies": { "scheduler": "^0.25.0" }, "peerDependencies": { "react": "^19.0.0" } }, "sha512-4GV5sHFG0e/0AD4X+ySy6UJd3jVl1iNsNHdpad0qhABJ11twS3TTBnseqsKurKcsNqCEFeGL3uLpVChpIO3QfQ=="],
+
+    "react-hook-form": ["react-hook-form@7.54.2", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg=="],
 
     "react-icons": ["react-icons@5.4.0", "", { "peerDependencies": { "react": "*" } }, "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ=="],
 

--- a/components/host/room-settings.tsx
+++ b/components/host/room-settings.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { Input } from "@/components/ui/input"
+import { SubmitButton } from "@/components/ui/submit-button"
+import { roomSettingsSchema } from "@/lib/schema/room-settings"
+import { ActionState, initialState } from "@/types/action-state"
+import { useActionState } from "react"
+import { Label } from "../ui/label"
+
+interface RoomSettingsFormProps {
+    action: (prevState: ActionState, formData: FormData) => Promise<ActionState>
+}
+
+export function RoomSettingsForm({ action }: RoomSettingsFormProps) {
+    const [state, formAction] = useActionState(action, initialState)
+
+    return (
+        <form action={formAction} className="flex flex-col gap-4">
+            <div className="space-y-2">
+                <Label htmlFor="max_songs_per_user">Max songs per user</Label>
+                <Input
+                    name="max_songs_per_user"
+                    type="number"
+                    defaultValue={2}
+                />
+                <p className="text-sm text-gray-500">
+                    {roomSettingsSchema.shape.max_songs_per_user.description}
+                </p>
+            </div>
+            {state?.error && (
+                <p className="text-sm text-red-600">{state.error}</p>
+            )}
+            <SubmitButton className="w-fit self-end">
+                Save settings
+            </SubmitButton>
+        </form>
+    )
+}

--- a/components/ui/form.tsx
+++ b/components/ui/form.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  ControllerProps,
+  FieldPath,
+  FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState, formState } = useFormContext()
+
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+    </FormItemContext.Provider>
+  )
+})
+FormItem.displayName = "FormItem"
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+})
+FormLabel.displayName = "FormLabel"
+
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      ref={ref}
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+})
+FormControl.displayName = "FormControl"
+
+const FormDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      ref={ref}
+      id={formDescriptionId}
+      className={cn("text-[0.8rem] text-muted-foreground", className)}
+      {...props}
+    />
+  )
+})
+FormDescription.displayName = "FormDescription"
+
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message) : children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      ref={ref}
+      id={formMessageId}
+      className={cn("text-[0.8rem] font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+})
+FormMessage.displayName = "FormMessage"
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+)
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+))
+Label.displayName = LabelPrimitive.Root.displayName
+
+export { Label }

--- a/lib/schema/room-settings.ts
+++ b/lib/schema/room-settings.ts
@@ -1,0 +1,14 @@
+import { z } from "zod"
+
+export const roomSettingsSchema = z.object({
+    max_songs_per_user: z
+        .number()
+        .min(1, {
+            message: "Maximum songs per user must be at least 1",
+        })
+        .describe(
+            "The maximum number of songs a single user can add to the queue at once.",
+        ),
+})
+
+export type RoomSettings = z.infer<typeof roomSettingsSchema>

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "dependencies": {
     "@formkit/auto-animate": "^0.8.2",
+    "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-progress": "^1.1.2",
     "@radix-ui/react-scroll-area": "^1.2.3",
     "@radix-ui/react-slot": "^1.1.2",
@@ -35,11 +37,13 @@
     "qrcode.react": "^4.2.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.2",
     "react-icons": "^5.4.0",
     "react-youtube": "^10.1.0",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
-    "ytmusic-api": "^5.3.0"
+    "ytmusic-api": "^5.3.0",
+    "zod": "^3.24.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.17",

--- a/types/action-state.ts
+++ b/types/action-state.ts
@@ -1,0 +1,13 @@
+export type ActionState = {
+    ok: boolean
+    error?: string
+}
+
+export type ActionStateWithData<T> = ActionState & {
+    data: T
+}
+
+export const initialState: ActionState = {
+    ok: true,
+    error: undefined,
+}


### PR DESCRIPTION
Host settings while in the room are still missing, I think there would have to be some invalidation logic going on too for that (because of people already in the room)

But this lays the groundwork for future additional settings that will be added later in time.

I don't think that we should merge this into master before the settings are also accessible in the room or we have an idea how the fallback playlist will look like, because currently it's a little empty, settings-wise.