### PR TITLE
fix(backend): restore @convex-dev/crons peer dep (fixes prod convex deploy)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -95,6 +95,7 @@
       "dependencies": {
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.92",
+        "@convex-dev/crons": "^0.2.0",
         "@convex-dev/stripe": "^0.1.4",
         "@erquhart/convex-oss-stats": "^0.8.2",
         "convex": "^1.39.1",
@@ -194,6 +195,8 @@
     "@chevrotain/types": ["@chevrotain/types@11.1.2", "", {}, "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw=="],
 
     "@convex-dev/auth": ["@convex-dev/auth@0.0.92", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0", "cookie": "^1.0.1", "is-network-error": "^1.1.0", "jose": "^5.2.2", "jwt-decode": "^4.0.0", "lucia": "^3.2.0", "oauth4webapi": "^3.1.2", "path-to-regexp": "^6.3.0", "server-only": "^0.0.1" }, "peerDependencies": { "@auth/core": "^0.37.0", "convex": "^1.17.0", "react": "^18.2.0 || ^19.0.0-0" }, "optionalPeers": ["react"], "bin": { "auth": "dist/bin.cjs" } }, "sha512-tNRIMTDxi2vrbT+3vz1FgNR1321IfIBDDBy59zul7E1DyzWQKoU0OzgFqWbiVm3o8gn0eQsYTU3UHNRX9kp3wQ=="],
+
+    "@convex-dev/crons": ["@convex-dev/crons@0.2.2", "", { "dependencies": { "cron-parser": "^4.9.0" }, "peerDependencies": { "convex": "^1.24.8" } }, "sha512-V5kLBb0kTb2MA6uN0MgEYEgeW1mp+1oioA0tnuh8yWZcb6FToY+e67MJ5SQ98N1JjY2K0JIofAzLUYe9gEdU2A=="],
 
     "@convex-dev/stripe": ["@convex-dev/stripe@0.1.4", "", { "dependencies": { "stripe": "^20.0.0" }, "peerDependencies": { "convex": "^1.29.3", "react": "^18.3.1 || ^19.0.0" } }, "sha512-HnINm3K2QHGvP0X4YV7KruCjQ1Ni0HE1qpJ5rZYjfdUbMcqJsX4ZYTmOo7tL83qtokS3EahKVkhXLCH/9Ms/og=="],
 
@@ -1091,6 +1094,8 @@
 
     "cose-base": ["cose-base@1.0.3", "", { "dependencies": { "layout-base": "^1.0.0" } }, "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg=="],
 
+    "cron-parser": ["cron-parser@4.9.0", "", { "dependencies": { "luxon": "^3.2.1" } }, "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q=="],
+
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "css-select": ["css-select@5.2.2", "", { "dependencies": { "boolbase": "^1.0.0", "css-what": "^6.1.0", "domhandler": "^5.0.2", "domutils": "^3.0.1", "nth-check": "^2.0.1" } }, "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw=="],
@@ -1636,6 +1641,8 @@
     "lucia": ["lucia@3.2.2", "", { "dependencies": { "@oslojs/crypto": "^1.0.1", "@oslojs/encoding": "^1.1.0" } }, "sha512-P1FlFBGCMPMXu+EGdVD9W4Mjm0DqsusmKgO7Xc33mI5X1bklmsQb0hfzPhXomQr9waWIBDsiOjvr1e6BTaUqpA=="],
 
     "lucide-react": ["lucide-react@1.17.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w=="],
+
+    "luxon": ["luxon@3.7.2", "", {}, "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -29,6 +29,7 @@
     "dependencies": {
         "@auth/core": "0.37.0",
         "@convex-dev/auth": "^0.0.92",
+        "@convex-dev/crons": "^0.2.0",
         "@convex-dev/stripe": "^0.1.4",
         "@erquhart/convex-oss-stats": "^0.8.2",
         "convex": "^1.39.1",


### PR DESCRIPTION
## Problem

The `songup` (web) production build fails at the **Convex deploy** step of `apps/web`'s `vercel-build` — `next build` succeeds, then:

```
✘ Could not resolve "@convex-dev/crons/convex.config"
   node_modules/@erquhart/convex-oss-stats/dist/component/convex.config.js:2:18
     import crons from "@convex-dev/crons/convex.config";
```

## Root cause

`packages/backend/convex/convex.config.ts` mounts `@erquhart/convex-oss-stats`, which mounts the `@convex-dev/crons` component and declares it as a **peerDependency** (`^0.2.0`). The now-deleted `apps/app` used to declare `@convex-dev/crons`, which Bun hoisted so the component resolved. The "Restructure to 3 apps" change removed that app, dropping `@convex-dev/crons` from the workspace **and from `bun.lock`**.

Local builds kept passing on stale hoisted `node_modules`; Vercel's clean install had no `@convex-dev/crons`, so `convex deploy` couldn't bundle the component.

## Fix

Declare `@convex-dev/crons@^0.2.0` in `packages/backend` (the package that mounts the component and runs `convex deploy`) and refresh `bun.lock`.

## Verification

- `bunx convex codegen` now bundles the component definitions cleanly (the exact step that failed on Vercel).
- Only `packages/backend/package.json` + `bun.lock` change.

## Rollout note

Once merged, promote `develop` → `master` to trigger the web production build. Nothing is down in the meantime — the previous production deployment is still serving songup.tv, and instant-rollback remains available. Zone config already verified: `songup` has `BLOG_DOMAIN`/`DOCS_DOMAIN`/`CONVEX_DEPLOY_KEY`; `blog.songup.tv` and `docs.songup.tv` are attached and return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)