### PR TITLE
Modernize blog navigation and styling

### DIFF
--- a/apps/blog/src/app/blog.css
+++ b/apps/blog/src/app/blog.css
@@ -16,12 +16,12 @@
     color: var(--blog-text);
 }
 
-article.x\:container {
+.blog-shell > article {
     max-width: 52rem;
     padding-bottom: 2rem;
 }
 
-header.x\:mb-8 {
+.blog-shell header {
     margin-block: 1.25rem 3rem;
     min-height: 2.5rem;
 }
@@ -37,7 +37,7 @@ header.x\:mb-8 {
     text-decoration: none;
 }
 
-.home-link span {
+.home-link-icon {
     display: grid;
     width: 1.75rem;
     height: 1.75rem;
@@ -48,7 +48,11 @@ header.x\:mb-8 {
     transition: background 150ms ease;
 }
 
-.home-link:hover span {
+.home-link-short {
+    display: none;
+}
+
+.home-link:hover .home-link-icon {
     background: var(--blog-panel-hover);
 }
 
@@ -174,22 +178,29 @@ header.x\:mb-8 {
     color: var(--blog-text);
 }
 
-small.x\:mt-32 {
+.blog-footer {
+    display: flex;
+    justify-content: space-between;
     margin-top: 4rem;
     padding-bottom: 1.5rem;
     color: var(--blog-muted);
+    font-size: 0.875rem;
+}
+
+.blog-footer a {
+    color: inherit;
 }
 
 @media (max-width: 640px) {
-    header.x\:mb-8 {
+    .blog-shell header {
         margin-bottom: 2rem;
     }
 
-    .home-link {
-        font-size: 0;
+    .home-link-full {
+        display: none;
     }
 
-    .home-link span {
-        font-size: 0.9rem;
+    .home-link-short {
+        display: inline;
     }
 }

--- a/apps/blog/src/app/blog.css
+++ b/apps/blog/src/app/blog.css
@@ -1,0 +1,195 @@
+:root {
+    color-scheme: dark;
+    --blog-text: #fff;
+    --blog-muted: rgb(255 255 255 / 65%);
+    --blog-border: rgb(255 255 255 / 18%);
+    --blog-panel: rgb(255 255 255 / 8%);
+    --blog-panel-hover: rgb(255 255 255 / 12%);
+}
+
+.songup-blog {
+    min-height: 100vh;
+    background:
+        radial-gradient(circle at 0% 0%, rgb(129 19 255 / 42%), transparent 36rem),
+        radial-gradient(circle at 100% 8%, rgb(0 135 255 / 28%), transparent 30rem),
+        #000;
+    color: var(--blog-text);
+}
+
+article.x\:container {
+    max-width: 52rem;
+    padding-bottom: 2rem;
+}
+
+header.x\:mb-8 {
+    margin-block: 1.25rem 3rem;
+    min-height: 2.5rem;
+}
+
+.home-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    margin-right: auto;
+    color: var(--blog-text);
+    font-size: 0.9rem;
+    font-weight: 650;
+    text-decoration: none;
+}
+
+.home-link span {
+    display: grid;
+    width: 1.75rem;
+    height: 1.75rem;
+    place-items: center;
+    border: 1px solid var(--blog-border);
+    border-radius: 0.5rem;
+    background: var(--blog-panel);
+    transition: background 150ms ease;
+}
+
+.home-link:hover span {
+    background: var(--blog-panel-hover);
+}
+
+.blog-intro {
+    border-bottom: 1px solid var(--blog-border);
+    padding-bottom: 2rem;
+}
+
+.blog-intro h1,
+.posts-page h1 {
+    margin: 0;
+    color: var(--blog-text);
+    font-size: clamp(2.1rem, 5vw, 3.25rem);
+    font-weight: 750;
+    letter-spacing: -0.055em;
+    line-height: 1;
+}
+
+.blog-intro p,
+.page-intro {
+    max-width: 40rem;
+    margin: 1rem 0 0;
+    color: var(--blog-muted);
+    font-size: 1.05rem;
+    line-height: 1.65;
+}
+
+.latest-posts,
+.posts-page {
+    margin-top: 2.5rem;
+}
+
+.section-heading {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.section-heading h2 {
+    margin: 0;
+    color: var(--blog-text);
+    font-size: 1.35rem;
+    font-weight: 700;
+    letter-spacing: -0.025em;
+}
+
+.text-link {
+    color: var(--blog-text);
+    font-size: 0.9rem;
+    font-weight: 650;
+    text-decoration: none;
+}
+
+.text-link:hover,
+.post-card h2 a:hover,
+.post-card p a:hover {
+    color: #c99cff;
+}
+
+.post-list {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.post-card {
+    border: 1px solid var(--blog-border);
+    border-radius: 0.625rem;
+    background: var(--blog-panel);
+    padding: 1.25rem 1.35rem;
+    backdrop-filter: blur(12px);
+    transition: background 150ms ease, border-color 150ms ease;
+}
+
+.post-card:hover {
+    border-color: rgb(255 255 255 / 30%);
+    background: var(--blog-panel-hover);
+}
+
+.post-card h2 {
+    margin-top: 0;
+    color: var(--blog-text);
+    font-size: 1.2rem;
+    letter-spacing: -0.02em;
+    line-height: 1.35;
+}
+
+.post-card p {
+    color: var(--blog-muted);
+    line-height: 1.55;
+}
+
+.post-card time {
+    display: inline-block;
+    margin-top: 0.5rem;
+    color: var(--blog-muted);
+}
+
+.posts-page .page-intro {
+    margin-bottom: 1.5rem;
+}
+
+.tag-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    margin-bottom: 1.5rem;
+}
+
+.tag-list .nextra-tag {
+    border: 1px solid var(--blog-border);
+    border-radius: 0.5rem;
+    background: var(--blog-panel);
+    padding: 0.28rem 0.6rem;
+    color: var(--blog-muted);
+    font-size: 0.82rem;
+    text-decoration: none;
+}
+
+.tag-list .nextra-tag:hover {
+    background: var(--blog-panel-hover);
+    color: var(--blog-text);
+}
+
+small.x\:mt-32 {
+    margin-top: 4rem;
+    padding-bottom: 1.5rem;
+    color: var(--blog-muted);
+}
+
+@media (max-width: 640px) {
+    header.x\:mb-8 {
+        margin-bottom: 2rem;
+    }
+
+    .home-link {
+        font-size: 0;
+    }
+
+    .home-link span {
+        font-size: 0.9rem;
+    }
+}

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from "next"
-import { Footer, Layout, Navbar, ThemeSwitch } from "nextra-theme-blog"
+import { Footer, Layout, Navbar } from "nextra-theme-blog"
 import { Head, Search } from "nextra/components"
 import { getPageMap } from "nextra/page-map"
 import "nextra-theme-blog/style.css"
+import "./blog.css"
 import { getSiteUrl } from "@/lib/site-url"
 
 const SITE_URL = getSiteUrl()
@@ -32,12 +33,17 @@ export default async function RootLayout({
 }) {
     return (
         <html lang="en" suppressHydrationWarning>
-            <Head backgroundColor={{ dark: "#0f172a", light: "#fefce8" }} />
-            <body>
-                <Layout>
+            <Head backgroundColor={{ dark: "#000000", light: "#000000" }} />
+            <body className="songup-blog">
+                <Layout nextThemes={{ forcedTheme: "dark" }}>
                     <Navbar pageMap={await getPageMap()}>
+                        {/* The Website zone owns this route. */}
+                        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                        <a href="/" className="home-link">
+                            <span aria-hidden="true">←</span>
+                            SongUp home
+                        </a>
                         <Search />
-                        <ThemeSwitch />
                     </Navbar>
 
                     {children}

--- a/apps/blog/src/app/layout.tsx
+++ b/apps/blog/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next"
-import { Footer, Layout, Navbar } from "nextra-theme-blog"
+import { Layout, Navbar } from "nextra-theme-blog"
 import { Head, Search } from "nextra/components"
 import { getPageMap } from "nextra/page-map"
 import "nextra-theme-blog/style.css"
@@ -35,26 +35,42 @@ export default async function RootLayout({
         <html lang="en" suppressHydrationWarning>
             <Head backgroundColor={{ dark: "#000000", light: "#000000" }} />
             <body className="songup-blog">
-                <Layout nextThemes={{ forcedTheme: "dark" }}>
-                    <Navbar pageMap={await getPageMap()}>
-                        {/* The Website zone owns this route. */}
-                        {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
-                        <a href="/" className="home-link">
-                            <span aria-hidden="true">←</span>
-                            SongUp home
-                        </a>
-                        <Search />
-                    </Navbar>
+                <div className="blog-shell">
+                    <Layout nextThemes={{ forcedTheme: "dark" }}>
+                        <Navbar pageMap={await getPageMap()}>
+                            {/* The Website zone owns this route. */}
+                            {/* eslint-disable-next-line @next/next/no-html-link-for-pages */}
+                            <a
+                                href="/"
+                                aria-label="SongUp home"
+                                className="home-link"
+                            >
+                                <span
+                                    aria-hidden="true"
+                                    className="home-link-icon"
+                                >
+                                    ←
+                                </span>
+                                <span className="home-link-label">
+                                    <span className="home-link-full">
+                                        SongUp home
+                                    </span>
+                                    <span className="home-link-short">
+                                        Home
+                                    </span>
+                                </span>
+                            </a>
+                            <Search />
+                        </Navbar>
 
-                    {children}
+                        {children}
 
-                    <Footer>
-                        {new Date().getFullYear()} © SongUp.
-                        <a href="/blog/rss.xml" style={{ float: "right" }}>
-                            RSS
-                        </a>
-                    </Footer>
-                </Layout>
+                        <footer className="blog-footer">
+                            {new Date().getFullYear()} © SongUp.
+                            <a href="/blog/rss.xml">RSS</a>
+                        </footer>
+                    </Layout>
+                </div>
             </body>
         </html>
     )

--- a/apps/blog/src/app/page.tsx
+++ b/apps/blog/src/app/page.tsx
@@ -9,23 +9,31 @@ export default async function HomePage() {
     const latestPosts = posts.slice(0, LATEST_POSTS_COUNT)
 
     return (
-        <div data-pagefind-ignore="all">
-            <h1>SongUp Blog</h1>
-            <p>
-                Welcome to the SongUp blog — the collaborative song request
-                queue for parties, bars, and events. Here we share product
-                updates, behind-the-scenes stories, and practical guides for
-                hosting unforgettable nights.
-            </p>
+        <div className="blog-home" data-pagefind-ignore="all">
+            <section className="blog-intro">
+                <h1>SongUp Blog</h1>
+                <p>
+                    Product updates, hosting tips, and music ideas for better
+                    parties, bars, and events.
+                </p>
+            </section>
 
-            <h2>Latest posts</h2>
-            {latestPosts.map((post) => (
-                <PostCard key={post.route} post={post} />
-            ))}
+            <section className="latest-posts" aria-labelledby="latest-posts">
+                <div className="section-heading">
+                    <h2 id="latest-posts">Latest posts</h2>
+                    <Link href="/posts" className="text-link">
+                        View all <span aria-hidden="true">→</span>
+                    </Link>
+                </div>
 
-            <p>
-                <Link href="/posts">Browse all posts →</Link>
-            </p>
+                <div className="post-list">
+                    {latestPosts.map((post) => (
+                        <article className="post-card" key={post.route}>
+                            <PostCard post={post} />
+                        </article>
+                    ))}
+                </div>
+            </section>
         </div>
     )
 }

--- a/apps/blog/src/app/posts/page.tsx
+++ b/apps/blog/src/app/posts/page.tsx
@@ -23,9 +23,7 @@ export default async function PostsPage() {
             <p className="page-intro">
                 Hosting guides, music inspiration, and SongUp news.
             </p>
-            <div
-                className="tag-list not-prose"
-            >
+            <div className="tag-list not-prose">
                 {Object.entries(allTags).map(([tag, count]) => (
                     <Link
                         key={tag}

--- a/apps/blog/src/app/posts/page.tsx
+++ b/apps/blog/src/app/posts/page.tsx
@@ -18,11 +18,13 @@ export default async function PostsPage() {
     }
 
     return (
-        <div data-pagefind-ignore="all">
+        <div className="posts-page" data-pagefind-ignore="all">
             <h1>Posts</h1>
+            <p className="page-intro">
+                Hosting guides, music inspiration, and SongUp news.
+            </p>
             <div
-                className="not-prose"
-                style={{ display: "flex", flexWrap: "wrap", gap: ".5rem" }}
+                className="tag-list not-prose"
             >
                 {Object.entries(allTags).map(([tag, count]) => (
                     <Link
@@ -34,9 +36,13 @@ export default async function PostsPage() {
                     </Link>
                 ))}
             </div>
-            {posts.map((post) => (
-                <PostCard key={post.route} post={post} />
-            ))}
+            <div className="post-list">
+                {posts.map((post) => (
+                    <article className="post-card" key={post.route}>
+                        <PostCard post={post} />
+                    </article>
+                ))}
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## What changed

- Refresh the blog with a restrained, content-first layout that matches SongUp’s dark landing-page palette.
- Add a persistent **SongUp home** link that navigates to the website root (`/`).
- Improve latest-post, tag, and all-post presentation with subtle glass panels and clearer spacing.

## Why

The blog previously had no route back to the main SongUp experience and used the theme’s default styling rather than the visual language of the landing page.

## Validation

- `bun --filter @songup/blog lint`
- `bun --filter @songup/blog check-types`
- Browser verification at `/blog`: content renders, six latest posts render, the home link resolves to `/`, and no console errors or error overlay were present.

> Note: the production build currently fails in existing MDX pages because metadata is exported from modules Next treats as client components; this is unrelated to the changes in this PR.
