### PR TITLE
fix(blog): restore Pagefind search and remove duplicate H1s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ coverage
 # next.js
 .next/
 out/
+apps/blog/public/_pagefind/
 
 # production
 build

--- a/apps/blog/package.json
+++ b/apps/blog/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "dev": "next dev --turbopack --port 3002",
         "build": "next build",
+        "postbuild": "pagefind --site .next/server/app --output-path public/_pagefind",
         "start": "next start --port 3002",
         "lint": "eslint .",
         "check-types": "tsc --noEmit"
@@ -24,6 +25,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.2.6",
+        "pagefind": "^1.5.2",
         "typescript": "^6.0.3"
     }
 }

--- a/apps/blog/src/app/posts/bar-playlist-ideas-that-keep-people-there/page.mdx
+++ b/apps/blog/src/app/posts/bar-playlist-ideas-that-keep-people-there/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/2945691/pexels-photo-2945691.jpeg
 ---
 
-# Bar Playlist Ideas That Keep Customers There Longer
-
 ![Patrons relaxing with drinks in a cozy, vintage-style bar lit with warm ambient lighting.](https://images.pexels.com/photos/2945691/pexels-photo-2945691.jpeg)
 
 Music is one of the most underrated levers a bar has for keeping customers in

--- a/apps/blog/src/app/posts/best-party-queue-apps-compared/page.mdx
+++ b/apps/blog/src/app/posts/best-party-queue-apps-compared/page.mdx
@@ -23,8 +23,6 @@ twitter:
     - https://images.pexels.com/photos/3249760/pexels-photo-3249760.jpeg
 ---
 
-# 8 Best Party Song Request & Queue Apps Compared (2026)
-
 ![A lively nightclub party crowd surrounded by colorful lights and confetti.](https://images.pexels.com/photos/3249760/pexels-photo-3249760.jpeg)
 
 Every party eventually hits the same problem: who controls the music? A wave of

--- a/apps/blog/src/app/posts/how-to-avoid-the-aux-cord-fight/page.mdx
+++ b/apps/blog/src/app/posts/how-to-avoid-the-aux-cord-fight/page.mdx
@@ -21,8 +21,6 @@ twitter:
     - https://images.pexels.com/photos/375751/pexels-photo-375751.jpeg
 ---
 
-# How to Avoid the Aux Cord Fight at Your Next Party
-
 ![A smartphone with a cable plugged into its audio jack, connected to a pair of red headphones.](https://images.pexels.com/photos/375751/pexels-photo-375751.jpeg)
 
 If you've hosted more than one party, you know the moment: someone's had the

--- a/apps/blog/src/app/posts/how-to-make-the-perfect-party-playlist/page.mdx
+++ b/apps/blog/src/app/posts/how-to-make-the-perfect-party-playlist/page.mdx
@@ -21,8 +21,6 @@ twitter:
     - https://images.pexels.com/photos/32589034/pexels-photo-32589034.jpeg
 ---
 
-# How to Make the Perfect Party Playlist (With or Without Help From Your Guests)
-
 ![Close-up of a DJ's hands mixing vinyl records on turntables at a live music event.](https://images.pexels.com/photos/32589034/pexels-photo-32589034.jpeg)
 
 A great party playlist isn't just a list of good songs — it's a list of good

--- a/apps/blog/src/app/posts/how-to-run-a-song-request-night/page.mdx
+++ b/apps/blog/src/app/posts/how-to-run-a-song-request-night/page.mdx
@@ -23,8 +23,6 @@ twitter:
     - https://images.pexels.com/photos/5156606/pexels-photo-5156606.jpeg
 ---
 
-# How to run a song request night
-
 ![A packed nightclub crowd dancing under vibrant lights with confetti falling over the room.](https://images.pexels.com/photos/5156606/pexels-photo-5156606.jpeg)
 
 A song request night is one of the easiest ways to turn a quiet weeknight into

--- a/apps/blog/src/app/posts/introducing-songup/page.mdx
+++ b/apps/blog/src/app/posts/introducing-songup/page.mdx
@@ -23,8 +23,6 @@ twitter:
     - https://images.pexels.com/photos/87216/pexels-photo-87216.jpeg
 ---
 
-# Introducing SongUp
-
 ![A smartphone held up against a glowing, colorful nightlife backdrop as someone films the party scene.](https://images.pexels.com/photos/87216/pexels-photo-87216.jpeg)
 
 Every great party has a soundtrack — and until now, that soundtrack lived on one

--- a/apps/blog/src/app/posts/office-party-playlist-ideas/page.mdx
+++ b/apps/blog/src/app/posts/office-party-playlist-ideas/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/6518728/pexels-photo-6518728.jpeg
 ---
 
-# Office Party Playlist Ideas That Work for Every Generation on Your Team
-
 ![Coworkers wearing festive holiday accessories laughing together at an office Christmas party.](https://images.pexels.com/photos/6518728/pexels-photo-6518728.jpeg)
 
 Company holiday parties, team offsites, and office happy hours have a music

--- a/apps/blog/src/app/posts/song-request-qr-code-guide/page.mdx
+++ b/apps/blog/src/app/posts/song-request-qr-code-guide/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/12935064/pexels-photo-12935064.jpeg
 ---
 
-# How to Set Up a Song Request QR Code for Your Party or Venue
-
 ![Close-up of a person holding up a smartphone to scan a QR code.](https://images.pexels.com/photos/12935064/pexels-photo-12935064.jpeg)
 
 QR code song requests have quietly become the standard way parties, bars, and

--- a/apps/blog/src/app/posts/songs-that-always-get-a-party-dancing/page.mdx
+++ b/apps/blog/src/app/posts/songs-that-always-get-a-party-dancing/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/342520/pexels-photo-342520.jpeg
 ---
 
-# 40 Songs That Always Get a Party Dancing (By Decade)
-
 ![Silhouetted people dancing on a nightclub dance floor bathed in vivid neon-colored lights.](https://images.pexels.com/photos/342520/pexels-photo-342520.jpeg)
 
 Some songs are practically guaranteed to get people out of their seats. Whether

--- a/apps/blog/src/app/posts/songup-vs-ampme/page.mdx
+++ b/apps/blog/src/app/posts/songup-vs-ampme/page.mdx
@@ -21,8 +21,6 @@ twitter:
     - https://images.pexels.com/photos/510507/pexels-photo-510507.jpeg
 ---
 
-# SongUp vs. AmpMe — Group Music Sync vs. Collaborative Song Requests
-
 ![A group of friends laughing together outdoors on a sunny day while one holds a cell phone.](https://images.pexels.com/photos/510507/pexels-photo-510507.jpeg)
 
 AmpMe and SongUp both get mentioned in "best party music app" searches, but

--- a/apps/blog/src/app/posts/songup-vs-festify/page.mdx
+++ b/apps/blog/src/app/posts/songup-vs-festify/page.mdx
@@ -21,8 +21,6 @@ twitter:
     - https://images.pexels.com/photos/7149136/pexels-photo-7149136.jpeg
 ---
 
-# SongUp vs. Festify — Voting Queue or Fair Request Queue for Your Party?
-
 ![A man showing his mobile phone screen to a group of friends at a gathering.](https://images.pexels.com/photos/7149136/pexels-photo-7149136.jpeg)
 
 Festify and SongUp are the two apps most likely to show up side by side in a

--- a/apps/blog/src/app/posts/songup-vs-spotify-jam/page.mdx
+++ b/apps/blog/src/app/posts/songup-vs-spotify-jam/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/4162583/pexels-photo-4162583.jpeg
 ---
 
-# SongUp vs. Spotify Jam — Which Is Better for Party Song Requests?
-
 ![A person wearing headphones while holding and browsing a smartphone streaming app.](https://images.pexels.com/photos/4162583/pexels-photo-4162583.jpeg)
 
 Spotify Jam and SongUp both promise the same thing: let more than one person control

--- a/apps/blog/src/app/posts/songup-vs-touchtunes/page.mdx
+++ b/apps/blog/src/app/posts/songup-vs-touchtunes/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/768036/pexels-photo-768036.jpeg
 ---
 
-# SongUp vs. TouchTunes — Best Jukebox Option for Bars and Venues
-
 ![A classic illuminated jukebox on display beside a vintage car in a retro indoor setting.](https://images.pexels.com/photos/768036/pexels-photo-768036.jpeg)
 
 TouchTunes has been the standard coin-and-credit-card jukebox in bars for years.

--- a/apps/blog/src/app/posts/wedding-reception-music-ideas-guests-choose/page.mdx
+++ b/apps/blog/src/app/posts/wedding-reception-music-ideas-guests-choose/page.mdx
@@ -22,8 +22,6 @@ twitter:
     - https://images.pexels.com/photos/15964962/pexels-photo-15964962.jpeg
 ---
 
-# Wedding Reception Music Ideas — Let Your Guests Help Choose the Songs
-
 ![Wedding guests dancing joyfully at an outdoor reception lit by strings of warm lights.](https://images.pexels.com/photos/15964962/pexels-photo-15964962.jpeg)
 
 Wedding reception music has to please a genuinely impossible mix of people:

--- a/bun.lock
+++ b/bun.lock
@@ -29,6 +29,7 @@
         "babel-plugin-react-compiler": "1.0.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "16.2.6",
+        "pagefind": "^1.5.2",
         "typescript": "^6.0.3",
       },
     },
@@ -523,6 +524,20 @@
     "@oslojs/crypto": ["@oslojs/crypto@1.0.1", "", { "dependencies": { "@oslojs/asn1": "1.0.0", "@oslojs/binary": "1.0.0" } }, "sha512-7n08G8nWjAr/Yu3vu9zzrd0L9XnrJfpMioQcvCMxBIiF5orECHe5/3J0jmXRVvgfqMm/+4oxlQ+Sq39COYLcNQ=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
+
+    "@pagefind/darwin-arm64": ["@pagefind/darwin-arm64@1.5.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MXpI+7HsAdPkvJ0gk9xj9g541BCqBZOBbdwj9g6lB5LCj6kSV6nqDSjzcAJwvOsfu0fjwvC8hQU+ecfhp+MpiQ=="],
+
+    "@pagefind/darwin-x64": ["@pagefind/darwin-x64@1.5.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-IojxFWMEJe0RQ7PQ3KXQsPIImNsbpPYpoZ+QUDrL8fAl/O27IX+LVLs74/UzEZy5uA2LD8Nz1AiwKr72vrkZQw=="],
+
+    "@pagefind/freebsd-x64": ["@pagefind/freebsd-x64@1.5.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-7EVzo9+0w+2cbe671BtMj10UlNo83I+HrLVLfRxO731svHRJKUfJ/mo05gU14pe9PCfpKNQT8FS3Xc/oDN6pOA=="],
+
+    "@pagefind/linux-arm64": ["@pagefind/linux-arm64@1.5.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Ovt9+K35sqzn8H3ZMXGwls4TD/wMJuvRtShHIsmUQREmaxjrDEX7gHckRCrwYJ4XE1H1p6HkLz3wukrAnsfXQw=="],
+
+    "@pagefind/linux-x64": ["@pagefind/linux-x64@1.5.2", "", { "os": "linux", "cpu": "x64" }, "sha512-V+tFqHKXhQKq/WqPBD67AFy7scn1/aZID00ws4fSDd+1daSi5UHR9VVlRrOUYKxn3VuFQYRD7lYXdZK1WED1YA=="],
+
+    "@pagefind/windows-arm64": ["@pagefind/windows-arm64@1.5.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-hN9Nh90fNW61nNRCW9ZyQrAj/mD0eRvmJ8NlTUzkbuW8kIzGJUi3cxjFkEcMZ5h/8FsKWD/VcouZl4yo1F7B6g=="],
+
+    "@pagefind/windows-x64": ["@pagefind/windows-x64@1.5.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg=="],
 
     "@panva/hkdf": ["@panva/hkdf@1.2.1", "", {}, "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw=="],
 
@@ -1871,6 +1886,8 @@
     "package-manager-detector": ["package-manager-detector@1.7.0", "", {}, "sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ=="],
 
     "paged-request": ["paged-request@2.0.2", "", { "dependencies": { "axios": "^0.21.1" } }, "sha512-NWrGqneZImDdcMU/7vMcAOo1bIi5h/pmpJqe7/jdsy85BA/s5MSaU/KlpxwW/IVPmIwBcq2uKPrBWWhEWhtxag=="],
+
+    "pagefind": ["pagefind@1.5.2", "", { "optionalDependencies": { "@pagefind/darwin-arm64": "1.5.2", "@pagefind/darwin-x64": "1.5.2", "@pagefind/freebsd-x64": "1.5.2", "@pagefind/linux-arm64": "1.5.2", "@pagefind/linux-x64": "1.5.2", "@pagefind/windows-arm64": "1.5.2", "@pagefind/windows-x64": "1.5.2" }, "bin": { "pagefind": "lib/runner/bin.cjs" } }, "sha512-XTUaK0hXMCu2jszWE584JGQT7y284TmMV9l/HX3rnG5uo3rHI/uHU56XTyyyPFjeWEBxECbAi0CaFDJOONtG0Q=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 


### PR DESCRIPTION
## Summary

- Remove the markdown H1 duplicated by Nextra from all 14 blog posts.
- Run Pagefind after the blog build and publish its generated bundle in `public/_pagefind`.
- Ignore generated Pagefind output; Nextra resolves the search import through the `/blog` base path, while the existing multi-zone rewrite serves `/blog/_pagefind/*`.

## Validation

- `bun run --cwd apps/blog check-types`
- `bun run --cwd apps/blog lint`
- Verified the local `/blog` route returns 200.
- Production build is currently blocked before Pagefind runs by the existing Nextra/Next MDX error: front-matter `metadata` is treated as an export from a client component. The same error occurs across all posts and is outside this focused change.

## Review monitoring

Future review loops will first fetch only the PR's latest review/comment timestamps or IDs. Full thread-aware GraphQL review-thread inspection runs only when that lightweight check changes; waits between checks use a Codex heartbeat automation rather than a terminal sleep loop.
